### PR TITLE
fix attribute to camelCase renamer, rmv stack vars

### DIFF
--- a/namer.js
+++ b/namer.js
@@ -66,6 +66,11 @@ function Namer() {
 
 
   var getNameByElement = function(element) {
+    //reuse var if no children elements, smaller JS stack
+    //textContent is prop assign, not an appendChild
+    if(element.children.length == 0) {
+        return base;
+    }
     // Get name by id
     if (typeof element.id !== 'undefined' && element.id !== '' && !isInUse(element.id)) {
       var name = element.id.camelize();
@@ -105,6 +110,18 @@ function Namer() {
     counter++;
     usedNames[base + counter] = true;
     return base + counter;
+  };
+
+  this.purgeName = function(name) {
+    //dont purge the 0 children node, no counter name
+    if(name.indexOf(base) == 0 && name.length > base.length) {
+        if(name != base + counter) {
+            debugger;
+            throw("purging wrong usedName entry");
+        }
+        delete usedNames[base + counter];
+        counter--;
+    }
   };
 
   var NAMES_TYPE = {


### PR DESCRIPTION
-serialize whole HTML body, not just body, this is for SPAes
-the dash-case HTML attributes to camelCase DOM props code was
 non-functional, nodeName vs nodeValue
-minimize stack var count and stack var scope, reuse them after declaring
-combine appendChild and CreateElement into 1 expression, saves bytecode
 and and ASCII code bytes