### PR TITLE
remove unused elem node assignments

### DIFF
--- a/html2js.js
+++ b/html2js.js
@@ -5,7 +5,9 @@
 var Html2js = function() {
   var NODE_TYPE = {
     //See: https://developer.mozilla.org/en/docs/Web/API/Node/nodeType#Constants
-    TEXT_NODE: 3
+    ELEMENT_NODE: 1,
+    TEXT_NODE: 3,
+    COMMENT_NODE: 8
   };
 
   var finalResult = '';
@@ -58,22 +60,35 @@ var Html2js = function() {
    * @description Append Attributes to element. work on/modify the global finalResult
    * @param element {HTMLElement}
    * @param name {string}
+   * @param maybeLValue {bool} last statment is hanging open
+   * for elemObj##\n\n\n##.prop="XYZ"; buffer line add on
    * @private
    */
-  function appendAttributes(element, name) {
+  function appendAttributes(element, name, maybeLValue) {
+    var getName = function() {
+      if(maybeLValue) {
+        maybeLValue = false;
+        return '';
+      } else {
+        return name;
+      }
+    };
     for (var i = 0; i < element.attributes.length; i++) {
       var attribute = element.attributes[i].nodeName;
 
       if (attribute.search('^data-') !== -1) {
-        var attributeName = attribute.substring(5);
+        var attributeName = attribute.substring(5)
+          .replace(/-([a-z])/g, (match, alpha) => alpha.toUpperCase());
         var value = element.attributes[i].value;
-        if (isNaN(value) || value === 'true' || value === 'false')
-          value = q + value + q;
+        var attr = element.attributes[i];
+        //if string or book wrap quotes
+        if (isNaN(value) || value === 'true' || value === 'false' || value === '')
+          value = quotesText(value);
 
-        finalResult += name + '.dataset.' + attributeName + ' = ' + value + ';\n';
+        finalResult += getName() + '.dataset.' + attributeName + ' = ' + value + ';\n';
         continue;
       } else if (attribute.search('^on') !== -1) {
-        finalResult += name + '.' + element.attributes[i].nodeName + ' = function(evt) {\n\t' + element.attributes[i].value + ';\n};\n';
+        finalResult += getName() + '.' + element.attributes[i].nodeName + ' = function(evt) {\n\t' + quotesText(element.attributes[i].value) + ';\n};\n';
         continue;
       }
 
@@ -81,7 +96,7 @@ var Html2js = function() {
         case 'class':
           var list = element.classList;
           for (var j = 0; j < list.length; j++) {
-            finalResult += name + '.classList.add(' + q + list[j] + q + ');\n';
+            finalResult += getName() + '.classList.add(' + q + list[j] + q + ');\n';
           }
           break;
         case 'style':
@@ -91,7 +106,7 @@ var Html2js = function() {
               var splitIdx = list[j].indexOf(':');
               var styleAttr = list[j].substring(0, splitIdx).trim();
               var stylevalue = list[j].substring(splitIdx + 1, list[j].length).trim();
-              finalResult += name + '.style.' + styleAttr.camelize() + ' = ' + q + stylevalue.camelize() + q + ';\n';
+              finalResult += getName() + '.style.' + styleAttr.camelize() + ' = ' + q + stylevalue.camelize() + q + ';\n';
             }
           }
           break;
@@ -118,7 +133,7 @@ var Html2js = function() {
         //convert things like http-equiv to httpEquiv
          nodeName = nodeName.toLowerCase().replace(/-\w/g, function(t){return t.substr(1).toUpperCase()});
 
-          finalResult += name + '.' + nodeName + ' = ' + q + element.attributes[i].nodeValue + q + ';\n';
+          finalResult += getName() + '.' + nodeName + ' = ' + quotesText(element.attributes[i].nodeValue) + ';\n';
       }
     }
 
@@ -133,8 +148,13 @@ var Html2js = function() {
     var re = new RegExp(q, 'g');
     var textArr = text.trim().split('\n');
     for (var i = 0; i < textArr.length; i++) {
-      textArr[i] = textArr[i].replace(re, '\\' + q);
-      textArr[i] = q + textArr[i].trim() + q;
+      /* use JSON.stringify ? */
+      textArr[i] = textArr[i].replace(/\\/g,'\\\\').replace(re, '\\' + q);
+/*    a // comment in a script element without a newline causes
+      a user agent syntax or fatal exception, new lines must stay
+      the original HTML can be minified to remove JS comments before
+      this lib is used */
+      textArr[i] = q + textArr[i].trim() + (textArr.length == 1 ? '' : '\\n') + q;
     }
     return textArr.join('\n+ ');
   }
@@ -147,36 +167,93 @@ var Html2js = function() {
    */
   function treeHTML(element, parentName) {
     var nodeList = element.childNodes;
-    var myName = namer.getName(element);
-    var varPrefix = usedNames[myName] ? '' : 'var ';
-    usedNames[myName] = true;
+/*    Only a node that turns into a textContent can be lvalue
+      prop assigned, comments and child elements are complicated,
+      child elements are not lvalue assignable because
+      its impossible to know at this point if rval of appendChild(createElement(())
+      has a func identifier to be saved to
+
+      appendChild(var nodeName3 = createElement('div')).class='abc',
+      nodeName3.textContent = 'xyz'
+
+      is illegal its too much work to separate
+
+      appendChild(var nodeName3 = createElement('div')).class='abc',
+      nodeName3.textContent = 'xyz'
+
+      appendChild(nodeName3 = createElement('div')).class='abc', nodeName3.textContent = 'xyz'
+
+      var nodeName2, nodeName3; someNode.appendChild(nodeName3 =
+      createElement('div')).class='abc', nodeName3.textContent = 'xyz'
+
+      since it would require 2 passes of code gen to generate the var decl list
+*/
+    var assignElem = (nodeList !== null && nodeList.length > 0
+      && (nodeList.length * (nodeList[0].nodeType == NODE_TYPE.TEXT_NODE ? 1 : 2)))|0;
+    var assignAttr = (typeof element.attributes !== 'undefined' && element.attributes.length)|0;
+    var assignStyle = (assignAttr && element.attributes[0].nodeName === 'style' ? 2 : 0);
+    var assignClass = (assignAttr && element.attributes[0].nodeName === 'class' ? 2 : 0);
+
+    var assignments = assignElem + assignAttr + assignStyle + assignClass;
+
+    var need_var = assignments == 0 || assignments == 1 ? false : true;
+    if (need_var) {
+      var myName = namer.getName(element);
+      var varPrefixDecl = usedNames[myName] ? '' : 'var ';
+      usedNames[myName] = true;
+    }
+    var maybeLValue = !varPrefixDecl;
+    var getName = function() {
+      if (maybeLValue) {
+        maybeLValue = false;
+        return '';
+      } else {
+        return myName;
+      }
+    };
 
     if (element.nodeType === NODE_TYPE.TEXT_NODE && element.nodeValue.trim() !== '') {
       finalResult += parentName + '.appendChild(document.createTextNode(' + quotesText(element.nodeValue.trim()) + '));\n';
-    } else {
-      finalResult += varPrefix + myName + ' = ' + parentName + '.appendChild(document.createElement(' + q + element.nodeName + q + '));\n';
+    } else if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
+      finalResult += (need_var ? (varPrefixDecl || '(') + myName + ' = ' : '')
+        + parentName + '.appendChild(document.createElement(' + q + element.nodeName + q
+        + (varPrefixDecl ? '));' : need_var ? ')))' : '))');
 
       if (typeof element.attributes !== 'undefined') {
-        if (element.attributes.length)
-          appendAttributes(element, myName);
+        if (element.attributes.length) {
+          appendAttributes(element, myName, maybeLValue);
+          maybeLValue = false;
+        }
       }
-    }
 
-    if (nodeList !== null && nodeList.length) {
-      if (nodeList.length === 1 && nodeList[0].nodeType === NODE_TYPE.TEXT_NODE) {
-        finalResult += myName + '.textContent = ' + quotesText(nodeList[0].nodeValue) + ';\n';
-      } else {
-        for (var i = 0; i < nodeList.length; i++) {
-          if (nodeList[i].nodeType === NODE_TYPE.TEXT_NODE && nodeList[i].nodeValue.trim() !== '') {
-            finalResult += myName + '.appendChild(document.createTextNode(' + quotesText(nodeList[i].nodeValue.trim()) + '));\n';
-          } else if (nodeList[i].nodeType === NODE_TYPE.TEXT_NODE) {
-            // nothing to do
-          } else {
-            treeHTML(nodeList[i], myName);
+      if (nodeList !== null && nodeList.length) {
+        if (nodeList.length === 1 && nodeList[0].nodeType === NODE_TYPE.TEXT_NODE) {
+          finalResult += getName() + '.textContent = ' + quotesText(nodeList[0].nodeValue) + ';\n';
+        } else {
+          for (var i = 0; i < nodeList.length; i++) {
+            if (nodeList[i].nodeType === NODE_TYPE.TEXT_NODE && nodeList[i].nodeValue.trim() !== '') {
+              finalResult += getName() + '.appendChild(document.createTextNode(' + quotesText(nodeList[i].nodeValue.trim()) + '));\n';
+            } else if (nodeList[i].nodeType === NODE_TYPE.TEXT_NODE
+              || nodeList[i].nodeType === NODE_TYPE.COMMENT_NODE) {
+              if (maybeLValue) { //lvalue never consumed
+                finalResult += ';\n';
+                maybeLValue = false;
+              }
+              // nothing to do
+            } else {
+              if (maybeLValue) { //lvalue never consumed
+                finalResult += ';\n';
+                maybeLValue = false;
+              }
+              treeHTML(nodeList[i], myName);
+            }
           }
         }
       }
+      if(maybeLValue) { //lvalue never consumed
+        finalResult += ';\n';
+      }
     }
-    namer.purgeName(myName);
+    myName && namer.purgeName(myName);
   }
 }

--- a/namer.js
+++ b/namer.js
@@ -68,7 +68,7 @@ function Namer() {
   var getNameByElement = function(element) {
     //reuse var if no children elements, smaller JS stack
     //textContent is prop assign, not an appendChild
-    if(element.children.length == 0) {
+    if(element.childNodes.length == 0) {
         return base;
     }
     // Get name by id


### PR DESCRIPTION
Various tweaks, I use this lib in a build process for a SPA router that keeps 404.html about 100 bytes long for caching/2G/3G reasons. 404.html is nothing but a script tag and preconnect link tags. html2js is used to package legacy HTML pages into 1 "404.js" file. I have a CLI tool that uses jsdom to run this lib in a build process, works well enough for me. I did some testing of the new code with with old.reddit.com and a couple other large sites to see if they render correct and they seem to do that. Thats how I found single quote in single quote and dataset bugs.


- e = t.appendChild(document.createElement('div')); e.id='abc';
to
- t.appendChild(document.createElement('div')).id='abc';

except if var decl.

Also skip unknown node types. comments and whitespace only text nodes
for example. Removing white space only text nodes causes layout issues
on some sites but the code did that already broke layout.

-fix // comments no newline in script tags causes JS error runtime

-contentEditable in the HTML demo isn't valid, fix case

-dataset needs proper var name conversion between XML and JS

-fix single quotes in quotes problems everywhere

-use element.childNodes consistently, var name depth went wrongusing
 children vs childNodes